### PR TITLE
Fix ArgumentError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /*.egg
 /*.egg-info
 .idea/
+venv/
+.vscode/

--- a/ctdl/ctdl.py
+++ b/ctdl/ctdl.py
@@ -250,8 +250,8 @@ def main():
 	parser.add_argument("-a", "--available", action='store_true',
 						help = "Get list of all available filetypes.")
 
-	parser.add_argument("-w", "--website", type = str,  default = "",
-						help = "specify website.")
+	# parser.add_argument("-w", "--website", type = str,  default = "",
+	# 					help = "specify website.")
 
 	parser.add_argument("-t", "--threats", action='store_true',
 						help = "Get list of all common virus carrier filetypes.")


### PR DESCRIPTION
I found that there are two `add_argument` for the `-w` argument, and this will cause `argparse.ArgumentError: argument -w/--website: conflicting option strings: -w, --website` this error.

I just commanded out the one with `default = " "`.